### PR TITLE
fix: Dump QAExchangeRecord on /send-question submission

### DIFF
--- a/acapy_plugin_qa/v1_0/routes.py
+++ b/acapy_plugin_qa/v1_0/routes.py
@@ -11,12 +11,12 @@ from aries_cloudagent.messaging.agent_message import AgentMessageSchema
 from aries_cloudagent.messaging.models.openapi import OpenAPISchema
 from aries_cloudagent.messaging.valid import UUIDFour
 from aries_cloudagent.storage.error import StorageNotFoundError
-from marshmallow import Schema, fields
+from marshmallow import fields
 
 from .message_types import SPEC_URI
 from .messages.answer import Answer
 from .messages.question import Question, QuestionSchema
-from .models.qa_exchange_record import QAExchangeRecord
+from .models.qa_exchange_record import QAExchangeRecord, QAExchangeRecordSchema
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,22 +45,10 @@ class QuestionRequestSchema(QuestionSchema):
     pass
 
 
-class QuestionRequestResponseSchema(Schema):
+class QuestionRequestResponseSchema(QAExchangeRecordSchema):
     """Schema for Question request response."""
 
-    class Meta:
-        model_class = Question
-
-    state = fields.Str(
-        required=True,
-        description=("The state of the question being asked."),
-        example="QUESTION_SENT",
-    )
-    question_id = fields.Str(
-        required=False,
-        description=("The associated ID of the question"),
-        example=UUIDFour.EXAMPLE,
-    )
+    pass
 
 
 class AnswerRequestSchema(AgentMessageSchema):
@@ -177,12 +165,7 @@ async def send_question(request: web.BaseRequest):
 
     await outbound_handler(msg, connection_id=connection_id)
 
-    return web.json_response(
-        {
-            "state": "QUESTION_SENT",
-            "question_id": msg._id,
-        }
-    )
+    return web.json_response(record.serialize())
 
 
 @docs(

--- a/int/tests/test_qa.py
+++ b/int/tests/test_qa.py
@@ -76,12 +76,14 @@ async def test_receive_question(
         f"{backchannel_endpoint}/qa/{connection_id}/send-question", json=question
     )
     assert r.status_code == 200
+    question_thread_id = r.json()["thread_id"]
 
     response = await echo.get_message(connection)
     assert response["@type"] == (
         "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/questionanswer/1.0/question"
     )
     thread_id = response["@id"]
+    assert thread_id == question_thread_id
 
     await echo.send_message(
         connection,
@@ -96,6 +98,7 @@ async def test_receive_question(
     results = r.json()["results"]
     assert results
     assert results[0]["response"]
+    assert results[0]["thread_id"] == thread_id
 
     r = httpx.delete(f"{backchannel_endpoint}/qa/{thread_id}")
     assert r.status_code == 200


### PR DESCRIPTION
After feedback from @reflectivedevelopment, it was recommended to just
dump the exchange record (following other conventions in ACA-Py) rather
than returning a customized response. Doing so returns the question_id
(as was the original request) along with it's state. The output format
is similar to the get-questions list call since the get-questions call
also returns the QAExchangeRecord.

Signed-off-by: Colton Wolkins (Indicio work address) <colton@indicio.tech>